### PR TITLE
hide menu-check/menu-label in html, instead of css

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -1,6 +1,6 @@
 <nav class="menu">
-  <input id="menu-check" type="checkbox" />
-  <label id="menu-label" for="menu-check" class="unselectable">
+  <input id="menu-check" type="checkbox" hidden/>
+  <label id="menu-label" for="menu-check" class="unselectable" hidden>
     <span class="icon close-icon">✕</span>
     <span class="icon open-icon">☰</span>
     <span class="text">Menu</span>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -208,14 +208,6 @@ body {
   content: "•\00a\000a0\00a0"
 }
 
-#menu-check {
-  display: none;
-}
-
-#menu-label {
-  display: none;
-}
-
 /* Main */
 
 .main .title h1 {


### PR DESCRIPTION
Clients without CSS will no longer see a menu which is useless to them.
The behavior for both desktop and mobile clients with CSS is unchanged.