### PR TITLE
trim blank lines left by templates in html

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,11 +1,10 @@
 {{ partial "header.html" . }}
+{{ .Content -}}
 
-{{ .Content }}
-
-{{ if .IsHome }}
-{{ $.Scratch.Set "pages" .Site.RegularPages }}
-{{ else }}
-{{ $.Scratch.Set "pages" .Pages }}
+{{ if .IsHome -}}
+{{ $.Scratch.Set "pages" .Site.RegularPages -}}
+{{ else -}}
+{{ $.Scratch.Set "pages" .Pages -}}
 {{ end }}
 <ul>
   {{ range (where ($.Scratch.Get "pages") "Section" "!=" "") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,5 @@
 {{ partial "header.html" . }}
 
-{{ if .Params.show_toc }} {{ .TableOfContents }} {{ end }}
+{{- if .Params.show_toc }} {{ .TableOfContents }} {{ end }}
 {{ .Content }}
-
 {{ partial "footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
   <footer>
-  {{ partial "foot_custom.html" . }}
-  {{ partial "footer_highlightjs" . }}
+  {{- partial "foot_custom.html" . -}}
+  {{ partial "footer_highlightjs" . -}}
   {{ with .Site.Params.footer }}
   <hr>
   <div class="copyright">{{ . | markdownify }}</div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,55 +3,54 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {{ if eq .RelPermalink "/" }}
+    {{ if eq .RelPermalink "/" -}}
     <title>{{ .Site.Title }}</title>
     <meta property="og:title" content="{{ .Site.Title }}">
     <meta property="og:type" content="website">
-    {{ else }}
+    {{- else -}}
     <title>{{ .Title }}{{ with .Params.subtitle }} - {{ . }} {{ end }} - {{ .Site.Title }}</title>
     <meta property="og:title" content="{{ .Title }} - {{ .Site.Title }}">
     {{ end }}
     <meta name="twitter:card" content="summary">
+    {{ with .Description -}}
+      {{- $.Scratch.Set "summary" (markdownify .) -}}
+    {{- else -}}
+      {{- $.Scratch.Set "summary" ((delimit (findRE "(<p.*?>(.|\n)*?</p>\\s*)+" .Content) "[&hellip;] ") | plainify | truncate (default 200 .Site.Params.summary_length) (default " &hellip;" .Site.Params.text.truncated)) -}}
+    {{- end -}}
 
-    {{ with .Description }}
-      {{ $.Scratch.Set "summary" (markdownify .) }}
-    {{ else }}
-      {{ $.Scratch.Set "summary" ((delimit (findRE "(<p.*?>(.|\n)*?</p>\\s*)+" .Content) "[&hellip;] ") | plainify | truncate (default 200 .Site.Params.summary_length) (default " &hellip;" .Site.Params.text.truncated)) }}
-    {{ end }}
-
-    {{ if eq .RelPermalink "/" }}
+    {{- if eq .RelPermalink "/" -}}
     <meta property="description" content="{{ .Site.Params.description }}">
-    {{ else }}
+    {{- else -}}
       {{ with ($.Scratch.Get "summary") }}
       <meta property="description" content="{{ . }}">
       <meta property="og:description" content="{{ . }}">
-      {{ end }}
-    {{ end }}
+      {{- end -}}
+    {{ end -}}
 
-    {{ range (findRE "<img src=\"https?://[^\"]+" .Content 1) }}
-    {{ $.Scratch.Set "autoImage" true }}
+    {{- range (findRE "<img src=\"https?://[^\"]+" .Content 1) -}}
+    {{- $.Scratch.Set "autoImage" true -}}
     <meta name="twitter:image" content="{{ replaceRE "<img src=\"" "" . | htmlUnescape }}">
-    {{ end }}
-    {{ with .Site.Params.twitterImage }}
-    {{ if not ($.Scratch.Get "autoImage") }}
+    {{- end -}}
+    {{- with .Site.Params.twitterImage -}}
+    {{- if not ($.Scratch.Get "autoImage") -}}
     <meta name="twitter:image" content="{{ absURL . }}">
-    {{ end }}
-    {{ end }}
+    {{- end -}}
+    {{- end -}}
 
-    {{ if .Keywords }}
+    {{- if .Keywords -}}
     <meta property="keywords" content ="{{ delimit .Keywords ", " }}">
-    {{ end }}
+    {{- end -}}
 
-    {{ with .OutputFormats.Get "RSS" }}
+    {{- with .OutputFormats.Get "RSS" }}
     <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-    {{ end }}
-    {{ partial "head_highlightjs" . }}
+    {{- end }}
+    {{- partial "head_highlightjs" . }}
     <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
     <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
-    {{ partial "head_custom.html" . }}
+    {{- partial "head_custom.html" . }}
   </head>
 
-  {{ $.Scratch.Set "section" (replaceRE "^/([^/]+)/.*" "$1" .RelPermalink) }}
+  {{- $.Scratch.Set "section" (replaceRE "^/([^/]+)/.*" "$1" .RelPermalink) }}
   <body class="{{ if .IsHome }}home{{ else }}{{ $.Scratch.Get "section" }}{{ end }}">
     <header class="masthead">
       {{ partial "tagline.html" . }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -6,10 +6,10 @@
     <span class="text">Menu</span>
   </label>
   <ul>
-  {{ $currentPage := . }}
-  {{ range (default .Site.Menus.main (index .Site.Menus ($.Scratch.Get "section"))) }}
+  {{- $currentPage := . }}
+  {{ range (default .Site.Menus.main (index .Site.Menus ($.Scratch.Get "section"))) -}}
   <li{{ if eq .URL $currentPage.RelPermalink }} class="active"{{ end }}><a href="{{ .URL }}">{{ .Name }}</a></li>
   {{ end }}
-  {{ partial "menu_extra.html" . }}
+  {{- partial "menu_extra.html" . -}}
   </ul>
 </nav>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -4,4 +4,4 @@
 <h3>{{ with .Params.author }}{{ . }}{{ end }}
 {{ if .Params.date }} {{ if .Params.author }} / {{ end }} {{ .Date.Format "2006-01-02" }}{{ end }}</h3>
 <hr>
-{{ end }}
+{{- end -}}

--- a/layouts/partials/tagline.html
+++ b/layouts/partials/tagline.html
@@ -1,3 +1,3 @@
 <h1><a href="{{ relURL "/" }}">{{ .Site.Title }}</a></h1>
 
-{{ with .Site.Params.Description }}<p class="tagline">{{ . }}</p>{{ end }}
+{{- with .Site.Params.Description }}<p class="tagline">{{ . }}</p>{{ end -}}


### PR DESCRIPTION
I noticed that the HTML output leaves a lot of blank lines, because only the templates themselves are removed during processing. So I used `{{- dashes next to the curly braces -}}` to remove some whitespace.