### PR TITLE
增加对 Google 版思源宋体（Noto Serif CJK SC）支持

### DIFF
--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -1,5 +1,5 @@
 body {
-  font-family: Optima, 'Lucida Sans', Calibri, Candara, Arial, 'source-han-serif-sc', 'Source Han Serif SC', 'Source Han Serif CN', 'Source Han Serif TC', 'Source Han Serif TW', 'Source Han Serif', 'Songti SC', 'Microsoft YaHei', sans-serif;
+  font-family: Optima, 'Lucida Sans', Calibri, Candara, Arial, 'source-han-serif-sc', 'Source Han Serif SC', 'Source Han Serif CN', 'Source Han Serif TC', 'Source Han Serif TW', 'Source Han Serif', 'Noto Serif CJK SC', 'Songti SC', 'Microsoft YaHei', sans-serif;
 }
 code {
   font-family: "Lucida Console", 'Andale Mono', 'STKaiti', 'KaiTi', 'SimKai', monospace;


### PR DESCRIPTION
Ubuntu 系统上使用的是 Google 版思源宋体，而不是 Adobe 版的，名称有差异，导致 Ubuntu 系统下思源字体不能正常渲染。