### PR TITLE
Allow required env vars for Hugo & CI build

### DIFF
--- a/exampleSite/config.yaml
+++ b/exampleSite/config.yaml
@@ -1,5 +1,5 @@
 baseurl: /
-locale: en-us
+locale: en-US
 title: Hugo Ivy
 theme: hugo-ivy
 ignoreFiles: ["\\.Rmd$", "\\.Rmarkdown$", "_cache$"]
@@ -35,7 +35,13 @@ params:
   highlightjsVersion: "11.7.0"
 
 security:
-  allowContent: ['.*']
+  allowContent:
+    - '.*'
+  funcs:
+    getenv:
+      - '^HUGO_'
+      - '^CI$'
+      - '^BLOGDOWN_'
 
 markup:
   highlight:


### PR DESCRIPTION
Update security settings for hugo 0.163.1:
- Keep original allowContent rule
- Add allowlist for getenv to access HUGO, CI, BLOGDOWN environment variables
Ensure normal site build and CI execution.

By the way, change locale "en-us" to "en-US".
